### PR TITLE
Doplnění Kameníkova atlasu a Rianův odkaz

### DIFF
--- a/Objekty/beings/dub-pameti.txt
+++ b/Objekty/beings/dub-pameti.txt
@@ -15,6 +15,7 @@ Dokáže naznačit cestu a předat útržky dávných myšlenek těm, kdo jej sl
 Dějiny:
 - -3200-04-14 — Ukázal cestu poutníkovi známému jako Sběrač hlasů (viz Příběhy/prvni-vek/pisen-u-jezera.txt).
 - -1850-01-01 — Naznačil cestu k Zahradě ticha mladému muži Lianovi (viz Příběhy/druhy-vek/zahrada-ticha.txt).
+- -1519-08-10 — Utěšil Riana a obnovil jeho odhodlání (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
 - -1200-09-09 — Varoval družinu sedmi na cestě do průsmyku (viz Příběhy/druhy-vek/pochod-stinu.txt).
 
 Poznámky:

--- a/Objekty/beings/rian.txt
+++ b/Objekty/beings/rian.txt
@@ -1,20 +1,24 @@
-
-
 id: obj:beings/rian
 jmeno: Rian
 kategorie: beings
-stav: zivy
+stav: mrtvy
 aliasy: Kartograf pocitů
 naposledy_upraveno: 2025-09-15
 
 Popis:
-Muž narozený se vzácnou a silnou schopností vnímat emoce a nálady krajiny. Svůj život zasvětil snaze tyto vjemy zmapovat a porozumět jim.
+Muž narozený se vzácnou a silnou schopností vnímat emoce a nálady krajiny. Svůj život zasvětil snaze tyto vjemy zmapovat a porozumět jim. Jeho životním dílem se stal Kamenný atlas.
 
 Dějiny:
 - -1550-03-12 — Narodil se v Osadě Vřesová stráň.
 - -1538 — Nastoupil do učení k tesaři, po večerech začal tajně kreslit své první "emoční" mapy okolí.
 - -1525-05-20 — Opustil svou rodnou osadu, aby se vydal na cestu a vytvořil atlas, který by zmapoval "duši" světa (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1521 (podzim) — Dorazil k Jezeru odrazu, kde zažil přetížení svých smyslů (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1519 (léto) — Zmapoval Údolí tichého strachu, kde jako první zaznamenal předzvěst budoucího Stínu (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1519-08-10 — Našel útěchu a obnovil své odhodlání u Dubu paměti (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1514 — Objevil Údolí tichých ozvěn a rozhodl se zde vytvořit své životní dílo (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1514 až -1466 — Téměř padesát let pracoval na tesání Kamenného atlasu do skalní stěny (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+- -1466 (zima) — Zemřel stářím u svého nedokončeného díla (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
 
 Poznámky:
-Jeho schopnost je intuitivní a vrozená. Není Nositel hlasů, ale spíše pasivní přijímač "hlasu země". Jeho mapy jsou pro běžné lidi nesrozumitelné.
+Jeho Kamenný atlas se stal trvalou součástí paměti světa, čitelnou pro jiné bytosti citlivé na hlas země.
 

--- a/Objekty/concepts/kamenny-atlas.txt
+++ b/Objekty/concepts/kamenny-atlas.txt
@@ -1,0 +1,16 @@
+id: obj:concepts/kamenny-atlas
+jmeno: Kamenný atlas
+kategorie: concepts
+stav: trvaly
+aliasy: Atlas duše světa
+naposledy_upraveno: 2025-09-15
+
+Popis:
+Rozsáhlé umělecké dílo vytesané do skalní stěny v Údolí tichých ozvěn kartografem pocitů Rianem. Nejedná se o mapu v tradičním smyslu, ale o fyzické ztvárnění emocí a nálad krajiny – smutku, radosti, hněvu a klidu.
+
+Dějiny:
+- -1514 až -1466 — Vytvářen Rianem jako jeho životní dílo (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+
+Poznámky:
+Atlas je pro běžné lidi nesrozumitelný. Pro bytosti citlivé na hlas země však slouží jako kronika a zdroj hlubokého porozumění. Samotné dílo je nabité emocemi, které do něj jeho tvůrce vtesal.
+

--- a/Objekty/concepts/tkalci-vzpominek.txt
+++ b/Objekty/concepts/tkalci-vzpominek.txt
@@ -1,0 +1,16 @@
+id: obj:concepts/tkalci-vzpominek
+jmeno: Tkalci Vzpomínek
+kategorie: concepts
+stav: trvaly
+aliasy: —
+naposledy_upraveno: 2025-09-15
+
+Popis:
+Společenství bytostí schopných propojovat a uchovávat vzpomínky krajiny. Jejich umění tkát z ozvěn minulosti má umožnit hlubší porozumění hlasu země.
+
+Dějiny:
+- Budoucnost — Jejich přesný původ je dosud nejasný; některé prameny je spojují s Kamenným atlasem (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+
+Poznámky:
+Zmíněni jako ti, kteří dokáží naslouchat Kamennému atlasu a číst jeho emocionální mapy.
+

--- a/Objekty/places/jezero-odrazu.txt
+++ b/Objekty/places/jezero-odrazu.txt
@@ -13,6 +13,7 @@ Dlouhé hledění do vody může člověku vzít kousek vlastní paměti a nahra
 
 Dějiny:
 - -3200-04-15 — Zazněla píseň slyšitelná všemi přítomnými (viz Příběhy/prvni-vek/pisen-u-jezera.txt).
+- -1521 (podzim) — Rian zažil u jezera přetížení svých smyslů a označil ho jako "chaos, který pohlcuje" (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
 
 Poznámky:
 Jedno z ohnisek, kde země mluví jasněji než jinde.

--- a/Objekty/places/udoli-ticheho-strachu.txt
+++ b/Objekty/places/udoli-ticheho-strachu.txt
@@ -1,0 +1,16 @@
+id: obj:places/udoli-ticheho-strachu
+jmeno: Údolí tichého strachu
+kategorie: places
+stav: neklidne
+aliasy: —
+naposledy_upraveno: 2025-09-15
+
+Popis:
+Odlehlé údolí, v němž panuje tíživé, nepřirozené ticho. Země zde působí, jako by zadržovala dech a sama se bála vlastního ozvěnu.
+
+Dějiny:
+- -1519 (léto) — Zmapoval je Rian a označil jako prázdné místo, předzvěst budoucího Stínu (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+
+Poznámky:
+O několik generací později se z tohoto ticha zrodil Stín, který přinesl zkázu do Dolního průsmyku.
+

--- a/Objekty/places/udoli-tichych-ozven.txt
+++ b/Objekty/places/udoli-tichych-ozven.txt
@@ -1,0 +1,17 @@
+id: obj:places/udoli-tichych-ozven
+jmeno: Údolí tichých ozvěn
+kategorie: places
+stav: trvale
+aliasy: —
+naposledy_upraveno: 2025-09-15
+
+Popis:
+Odlehlé, zapomenuté údolí sevřené mezi třemi skalnatými vrcholy. Místo je charakteristické hlubokým klidem a je plné jemných ozvěn dávných událostí a nálad krajiny.
+
+Dějiny:
+- -1514 — Objeveno Rianem, který si ho zvolil za místo pro své životní dílo.
+- -1514 až -1466 — Stalo se domovem Riana a místem vzniku Kamenného atlasu (viz Příběhy/druhy-vek/kameníkuv-atlas.txt).
+
+Poznámky:
+Po Rianově smrti se údolí a jeho atlas staly cílem tichých poutí pro ty, kteří dokáží vnímat hlas země.
+

--- a/Příběhy/druhy-vek/kameníkuv-atlas.txt
+++ b/Příběhy/druhy-vek/kameníkuv-atlas.txt
@@ -2,7 +2,7 @@
 id: st:druhy-vek/kameníkuv-atlas
 nazev: Kameníkův atlas
 era: druhy-vek
-casovy_rah: -1550-03-12 až -1519-08-10
+casovy_rah: -1550-03-12 až -1466-12-01
 autor: Kronikář
 nemenny: ano
 
@@ -10,6 +10,8 @@ Obsah:
 ČÁST I: Dětství a Probuzení
 
 ČÁST II: Cesta a Pochybnost
+
+ČÁST III: Mistrovství a Odkaz
 
 První léta Rianova putování byla plná samoty. Lidem se vyhýbal, jejich myšlenky a emoce pro něj byly příliš chaotické, příliš ostré. Jeho společníky byly vítr, déšť a tichý šepot země, který se učil rozlišovat. Jeho mapy se plnily symboly. Zjistil, že radost krajiny často kreslí jako soustředné kruhy, zatímco starý smutek jako hluboké, rovné rýhy.
 
@@ -32,3 +34,17 @@ Roku -1538, když mu bylo dvanáct let, ho otec poslal do učení k tesaři Jorn
 Roky plynuly. Rian dospěl v mlčenlivého mladého muže, jehož jedinými přáteli byly jeho mapy a pocity krajiny. Věděl, že v osadě pro něj není místo. Jeho vnímání světa bylo pro ostatní jen podivínstvím. Rozhodnutí v něm zrálo pomalu, jako semeno v zemi.
 
 Na jaře roku -1525, krátce po svých pětadvacátých narozeninách, se rozhodl. V noci sbalil svůj skromný majetek: náhradní tuniku, nůž, křesadlo a svitky pergamenu, na které nakreslil své podivné mapy. Nechal je ležet na stole v tesařově dílně. Nebyly pro ostatní. Byly jen důkazem, že se nezbláznil. Za úsvitu dne 20. května -1525 opustil Vřesovou stráň. Neohlédl se. Jeho cílem nebylo nic menšího než vytvořit atlas celého světa. Atlas, který by nezachycoval jen jeho tělo, ale i jeho duši.
+ČÁST III: Mistrovství a Odkaz
+
+Po setkání s Dubem paměti Rian opustil myšlenku na mapování celého světa. Pochopil, že jeho úkolem není obsáhnout vše, ale dokonale porozumět jednomu místu a v něm zanechat svůj odkaz. Pět let hledal, až konečně v roce -1514 našel to, co jeho srdce poznalo jako svůj cíl: zapomenuté, bezejmenné údolí sevřené mezi třemi skalnatými vrcholy. Údolí bylo tiché, ale ne prázdné jako Údolí tichého strachu. Bylo plné ozvěn – ozvěn dávných větrů, ozvěn růstu skal a ozvěn ticha samotného. Nazval ho Údolí tichých ozvěn.
+
+Zde Rian pochopil, že pergamen a uhlík jsou příliš pomíjivé, aby zachytily věčnost. Jeho dílo musí být vytesáno do materiálu, který má paměť sám o sobě – do kamene. V údolí se nacházela mohutná, hladká skalní stěna, chráněná před nejhoršími větry. To se mělo stát jeho plátnem.
+
+Po zbytek svého života Rian pracoval. Opustil myšlenku na symboly a začal tesat samotné pocity. Hněv a sílu horských bystřin vytesal jako hluboké, divoké rýhy, které se sbíhaly a rozbíhaly. Klid a mír lesní mýtiny ztvárnil jako hladce opracované, jemně zvlněné plochy, které lákaly k doteku. Prastarý smutek země vyjádřil jako obrovské, dolů směřující oblouky, z nichž jako by kanuly kamenné slzy. Jeho dílo nebylo mapou v pravém slova smyslu. Byl to Kamenný atlas – atlas duše světa, přeložený do jazyka dláta a kamene.
+
+Nepracoval pro lidi, nehledal uznání. Pracoval v tichém dialogu se zemí. Někdy celé měsíce jen seděl a naslouchal, než udělal jediný úder. Jeho ruce zesílily a zhrubly, jeho tvář ošlehal vítr a jeho vlasy zbělely jako sníh na vrcholcích hor. Stal se součástí údolí, stejně jako skály a stromy.
+
+Rian zemřel stářím na začátku zimy roku -1466, s dlátem v ruce, opřený o své nedokončené dílo. Našel ho až po letech zbloudilý lovec, který nechápal, co vidí. Zpráva o "podivínovi, co kreslil do skal" se donesla do okolních osad, ale brzy byla zapomenuta.
+
+Jeho Kamenný atlas však zůstal. Pro většinu lidí byl jen nesrozumitelnou změťí rýh a tvarů. Ale pro ty, kteří uměli naslouchat – pro zbloudilé poutníky s citlivou duší, pro budoucí Tkalce Vzpomínek či Nositelé hlasů – se jeho dílo stalo posvátným místem. Nebylo to jen zobrazení. Samotný atlas byl nabitý emocemi, které do něj Rian vytesal. Dotknout se ho znamenalo pocítit klid, smutek i radost země. Rianův život, který začal v osamění a nepochopení, tak zanechal ve světě trvalou, hmatatelnou ozvěnu. Stal se součástí paměti, kterou se celý život snažil zmapovat.
+

--- a/timeline.txt
+++ b/timeline.txt
@@ -13,6 +13,12 @@
 - **-1540 (cca)** — Rian v dětství navštěvoval Lom tichých vzdechů a vnímal jeho melancholickou atmosféru (viz Příběhy/druhy-vek/kameníkuv-atlas.txt, Objekty/places/lom-tichych-vzdechu.txt).
 - **-1538** — Rian nastoupil do učení k tesaři Jornovi a začal kreslit své první "emoční" mapy (viz Příběhy/druhy-vek/kameníkuv-atlas.txt, Objekty/beings/rian.txt).
 - **-1525-05-20** — Rian opustil Osadu Vřesová stráň, aby vytvořil atlas světa (viz Příběhy/druhy-vek/kameníkuv-atlas.txt, Objekty/beings/rian.txt, Objekty/places/osada-vresova-stran.txt).
+- **-1521 (podzim)** — Rian zažil u Jezera odrazu přetížení svých smyslů a označil ho jako "chaos, který pohlcuje" (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/places/jezero-odrazu.txt).
+- **-1519 (léto)** — Rian zmapoval Údolí tichého strachu a zaznamenal předzvěst budoucího Stínu (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/places/udoli-ticheho-strachu.txt).
+- **-1519-08-10** — Dub paměti poskytl Rianovi klid a obnovil jeho odhodlání (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/beings/dub-pameti.txt).
+- **-1514** — Rian objevil Údolí tichých ozvěn a zahájil práci na Kamenném atlasu (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/places/udoli-tichych-ozven.txt).
+- **-1514 až -1466** — V Údolí tichých ozvěn tesal Kamenný atlas (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/concepts/kamenny-atlas.txt).
+- **-1466 (zima)** — Rian zemřel u svého nedokončeného díla (viz Příběhy/druhy-vek/kameníkuv-atlas.txt; Objekty/beings/rian.txt).
 - **-1850-01-01** — Mladý muž Lian pocházel z nedaleké osady a často navštěvoval okolní lesy (viz Příběhy/druhy-vek/zahrada-ticha.txt). Lian navštívil Zahradu ticha a zamiloval se do Lyry (viz Objekty/beings/lian.txt, Objekty/places/zahrada-ticha.txt).
 - **-1850-12-31** — Lyra, utkaná z paměti Zahrady ticha, byla ovlivněna Lianovou láskou, což vedlo k proměně její podstaty a chřadnutí zahrady. Lian odešel (viz Příběhy/druhy-vek/zahrada-ticha.txt, Objekty/beings/lyra.txt, Objekty/places/zahrada-ticha.txt).
 - **-1200-09-01** — Poslové vysláni varovat okolí před Stínem v Dolním průsmyku (viz Příběhy/druhy-vek/pochod-stinu.txt).


### PR DESCRIPTION
## Shrnutí
- Uzavřena Rianova cesta třetí částí příběhu a rozšířen časový rámec až k jeho smrti.
- Přidány objekty Údolí tichých ozvěn, Kamenný atlas, Údolí tichého strachu a koncept Tkalců Vzpomínek.
- Rian, Dub paměti a Jezero odrazu získaly nové záznamy; časová osa zachycuje jeho mistrovství a odkaz.

## Dotčené objekty
- `obj:beings/rian`
- `obj:places/udoli-tichych-ozven`
- `obj:concepts/kamenny-atlas`
- `obj:places/udoli-ticheho-strachu`
- `obj:concepts/tkalci-vzpominek`
- `obj:beings/dub-pameti`
- `obj:places/jezero-odrazu`


------
https://chatgpt.com/codex/tasks/task_e_68c754ffaa2083339d2f8c5ef95606bb