### PR TITLE
Add export script for AI ingestion

### DIFF
--- a/Pokyny/README.txt
+++ b/Pokyny/README.txt
@@ -1,13 +1,15 @@
 
 POKYNY PRO TVORBU A REVIEW (PRO LIDI I PRO OPENHANDS)
 
+Repo obsahuje pomocný skript `export.sh` pro sloučení textů do tří souborů.
+
 Co má OpenHands dělat:
 1) Tvořit nové Příběhy (neměnné), případně k nim přidat/aktualizovat Objekty.
 2) Přidávat nové Objekty nebo rozšiřovat jejich „Dějiny“ (stav, milníky).
 3) Dopisovat Legendy (základní pravdy, mechaniky, slovník pojmů).
 
 Co NEMÁ dělat:
-- Neprogramuje. Nepřidává skripty ani nástroje.
+- Neprogramuje. Kromě existujícího `export.sh` nepřidává další skripty ani nástroje.
 - Nemění již schválené Příběhy. Vždy raději upraví Objekty.
 - Nevkládá spekulace bez opory v Příbězích nebo Legendách (nejistoty → do Poznámek objektu).
 - Nemění již schválenou časovou osu bez úpravy souvisejících Příběhů nebo Objektů.

--- a/README.txt
+++ b/README.txt
@@ -9,12 +9,13 @@ Složky:
 - Pokyny/    — závazná pravidla, checklisty a postupy pro práci (pro lidi i OpenHands).
 - timeline.txt — chronologický přehled událostí univerza.
 - AGENTS.md — rychlé pokyny pro OpenHands.
+- export.sh  — skript pro sloučení textů do tří souborů.
 
 Základní pravidla:
 - Příběhy jsou neměnné po schválení. Pokud něco nesedí, upravují se Objekty.
 - Objekty musí být konzistentní s Příběhy i Legendami.
 - Každá změna probíhá přes Pull Request s checklistem v Pokyny/PR-POKYNY.txt.
-- Všechno je v prostém textu. Žádné skripty. Žádné generované soubory.
+- Všechno je v prostém textu. Žádné generované soubory. (Existuje pouze pomocný skript `export.sh`.)
 
 Cíl:
 - OpenHands (AI) má na základě Pokyny/… psát příběhy, přidávat/aktualizovat objekty a doplňovat legendy tak, aby byl svět soudržný.

--- a/export.sh
+++ b/export.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_STORIES="export_pribehy.txt"
+OUTPUT_OBJECTS="export_objekty.txt"
+OUTPUT_OTHER="export_ostatni.txt"
+
+rm -f "$OUTPUT_STORIES" "$OUTPUT_OBJECTS" "$OUTPUT_OTHER"
+
+aggregate() {
+  local dir="$1"
+  local target="$2"
+  find "$dir" -type f \( -name "*.txt" -o -name "*.md" \) -print0 | sort -z | while IFS= read -r -d '' file; do
+    printf '##### %s #####\n' "${file#./}" >> "$target"
+    cat "$file" >> "$target"
+    printf '\n\n' >> "$target"
+  done
+}
+
+aggregate "Příběhy" "$OUTPUT_STORIES"
+aggregate "Objekty" "$OUTPUT_OBJECTS"
+
+find . -type f \( -name "*.txt" -o -name "*.md" \) \
+  ! -path "./Příběhy/*" ! -path "./Objekty/*" \
+  ! -path "./.git/*" \
+  ! -name "$OUTPUT_STORIES" ! -name "$OUTPUT_OBJECTS" ! -name "$OUTPUT_OTHER" \
+  ! -name "export.sh" \
+  -print0 | sort -z | while IFS= read -r -d '' file; do
+    printf '##### %s #####\n' "${file#./}" >> "$OUTPUT_OTHER"
+    cat "$file" >> "$OUTPUT_OTHER"
+    printf '\n\n' >> "$OUTPUT_OTHER"
+  done


### PR DESCRIPTION
## Summary
- add `export.sh` script to bundle stories, objects and other texts into three files
- document the export script in README and guidelines

## Testing
- `./export.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c82de98e648333ae905738cb797246