### PR TITLE
Přidání příběhu Průsmyk falešných jmen

### DIFF
--- a/Objekty/beings/joric-kartograf.txt
+++ b/Objekty/beings/joric-kartograf.txt
@@ -1,17 +1,25 @@
 id: obj:beings/joric-kartograf
 jmeno: Joric
 kategorie: beings
-stav: zivy
+stav: zivy (otřesený)
 aliasy: —
 naposledy_upraveno: 2025-09-16
 
 Popis:
-Mladý, ale velmi talentovaný kartograf řádu Šedých svědků. Specializuje se na "křehkou kartografii" – mapování oblastí s nestabilní realitou, kde se klasické mapy stávají bezcennými. Jeho úkolem je zaznamenávat projevy "odmazávání" a pokusit se zmapovat hranice a šíření nové anomálie.
+Mladý, ale velmi talentovaný kartograf řádu Šedých svědků. Specializuje se na 'křehkou kartografii'
+– mapování oblastí s nestabilní realitou, kde se klasické mapy stávají bezcennými. Jeho úkolem je
+zaznamenávat projevy 'odmazávání' a pokusit se zmapovat hranice a šíření nové anomálie.
 
 Dějiny:
 - +190 (cca) — Narodil se.
-- +215 (jaro) — Je vybrán jako třetí člen expedice k Poslednímu bdění (viz Příběhy/jizva-ticha/1/2.txt).
-- +215 (jaro) — Během cesty Lesem šepotů se pokouší zaznamenat jeho narušenou paměť (viz Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — Je vybrán jako třetí člen expedice k Poslednímu bdění (viz
+  Příběhy/jizva-ticha/1/2.txt).
+- +215 (jaro) — Během cesty Lesem šepotů se pokouší zaznamenat jeho narušenou paměť (viz
+  Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — V Průsmyku bezejmenných se stává první obětí nové formy útoku Hlasu Nicoty. Jeho
+  identita je dočasně přepsána falešnou vzpomínkou. Z tohoto stavu ho vysvobodí Kaelen. Tato událost
+  ho hluboce traumatizuje, ale zároveň mu poskytne jedinečný vhled do povahy hrozby (viz
+  Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Jeho dovednosti mohou být klíčové pro pochopení povahy Hlasu Nicoty.
+Jeho zkušenost z něj činí klíčového svědka pro pochopení mechanismu 'přepisování' reality.

--- a/Objekty/beings/kaelen-z-udoli.txt
+++ b/Objekty/beings/kaelen-z-udoli.txt
@@ -6,13 +6,26 @@ aliasy: —
 naposledy_upraveno: 2025-09-16
 
 Popis:
-Mladý a idealistický akolyta řádu Šedých svědků, který vyrostl v Údolí tichých ozvěn. Je hluboce sečtělý v historii a legendách Věků, se zvláštním zaměřením na hrdinské činy minulosti. Má výjimečný cit pro Kamenný atlas, který nevnímá jen jako historický artefakt, ale jako živoucí text. Ačkoliv je teoreticky velmi zdatný, postrádá praktické zkušenosti se světem mimo bezpečí údolí.
+Mladý a idealistický akolyta řádu Šedých svědků, který vyrostl v Údolí tichých ozvěn. Je hluboce
+sečtělý v historii a legendách Věků, se zvláštním zaměřením na hrdinské činy minulosti. Má výjimečný
+cit pro Kamenný atlas, který nevnímá jen jako historický artefakt, ale jako živoucí text. Ačkoliv je
+teoreticky velmi zdatný, postrádá praktické zkušenosti se světem mimo bezpečí údolí.
 
 Dějiny:
 - cca +195 — Narodil se v Údolí tichých ozvěn.
-- +215 (jaro) — Jako učeň Mistra Eliana se stává svědkem zpráv o zhoršující se situaci na hranici Tiché prázdnoty (viz Příběhy/jizva-ticha/1/1.txt).
-- +215 (jaro) — Poté, co mu je odepřena účast v oficiální expedici, objeví v posledních zprávách z Posledního bdění skryté varování. Rozhodne se neuposlechnout rozkazy a vydá se tajně po stopách expedice na sever (viz Příběhy/jizva-ticha/1/2.txt).
-- +215 (jaro) — Vstupuje do Lesa šepotů. Poprvé se setkává s projevem "falešných ozvěn" a uvědomuje si, že vliv Prázdnoty sahá dál, než se předpokládalo. Zažívá první letmý dotek "odmazávání" (viz Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — Jako učeň Mistra Eliana se stává svědkem zpráv o zhoršující se situaci na hranici
+  Tiché prázdnoty (viz Příběhy/jizva-ticha/1/1.txt).
+- +215 (jaro) — Poté, co mu je odepřena účast v oficiální expedici, objeví v posledních zprávách z
+  Posledního bdění skryté varování. Rozhodne se neuposlechnout rozkazy a vydá se tajně po stopách
+  expedice na sever (viz Příběhy/jizva-ticha/1/2.txt).
+- +215 (jaro) — Vstupuje do Lesa šepotů. Poprvé se setkává s projevem 'falešných ozvěn' a uvědomuje
+  si, že vliv Prázdnoty sahá dál, než se předpokládalo. Zažívá první letmý dotek 'odmazávání' (viz
+  Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — Dostihne expedici u Průsmyku bezejmenných a varuje ji před 'falešnými ozvěnami'. Své
+  znalosti prokáže, když zachrání Jorica před pohlcením falešnou identitou tím, že použije sdílenou
+  vzpomínku na Kamenný atlas jako mentální kotvu. Získává neochotný respekt Rhey (viz
+  Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Jeho jméno je ozvěnou jmen významných postav minulosti (Kaelen, První mluvčí; kameník Kael; lovec Kaelan), což může symbolizovat tíhu dědictví, které nese.
+Jeho jméno je ozvěnou jmen významných postav minulosti (Kaelen, První mluvčí; kameník Kael; lovec
+Kaelan), což může symbolizovat tíhu dědictví, které nese.

--- a/Objekty/beings/orin-stopar.txt
+++ b/Objekty/beings/orin-stopar.txt
@@ -6,12 +6,19 @@ aliasy: Tichý Orin
 naposledy_upraveno: 2025-09-16
 
 Popis:
-Stopař a lovec řádu Šedých svědků. Je to mlčenlivý muž, který většinu svého života strávil sám v divočině obklopující Údolí tichých ozvěn. Dokáže číst stopy a znamení v krajině s neuvěřitelnou přesností a je expertem na přežití v nehostinných Tichých vrších. Jeho schopnosti jsou čistě praktické, založené na pozorování a zkušenosti.
+Stopař a lovec řádu Šedých svědků. Je to mlčenlivý muž, který většinu svého života strávil sám v
+divočině obklopující Údolí tichých ozvěn. Dokáže číst stopy a znamení v krajině s neuvěřitelnou
+přesností a je expertem na přežití v nehostinných Tichých vrších. Jeho schopnosti jsou čistě
+praktické, založené na pozorování a zkušenosti.
 
 Dějiny:
 - +175 (cca) — Narodil se mimo Údolí a k řádu se přidal v dospělosti.
-- +215 (jaro) — Je vybrán jako člen expedice k Poslednímu bdění díky svým jedinečným stopařským schopnostem (viz Příběhy/jizva-ticha/1/2.txt).
+- +215 (jaro) — Je vybrán jako člen expedice k Poslednímu bdění díky svým jedinečným stopařským
+  schopnostem (viz Příběhy/jizva-ticha/1/2.txt).
 - +215 (jaro) — Prochází s expedicí Lesem šepotů (viz Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — U Průsmyku bezejmenných stojí po boku Rhey, když falešná ozvěna přepíše Joricovu
+  identitu. Pomáhá ho uzemnit a potvrzuje Kaelenovo varování (viz Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Jeho role ve společenstvu bude později z velké části zastoupena Eamonem z Břehů, což může vést k zajímavé dynamice nebo tragickému osudu.
+Jeho role ve společenstvu bude později z velké části zastoupena Eamonem z Břehů, což může vést k
+zajímavé dynamice nebo tragickému osudu.

--- a/Objekty/beings/rhea-seda-svedkyne.txt
+++ b/Objekty/beings/rhea-seda-svedkyne.txt
@@ -6,13 +6,22 @@ aliasy: Rhea Hraničářka
 naposledy_upraveno: 2025-09-16
 
 Popis:
-Zkušená členka řádu Šedých svědků a bývalá velitelka stráží na hranici s Tichou prázdnotou. Je to pragmatická a strohá žena, zvyklá na drsné podmínky a neustálý psychický tlak. Má hluboké, praktické znalosti o projevech Prázdnoty, ale postrádá Kaelenovu teoretickou a filozofickou hloubku. Její přístup je založen na přežití a zadržování hrozby, ne na jejím pochopení.
+Zkušená členka řádu Šedých svědků a bývalá velitelka stráží na hranici s Tichou prázdnotou. Je to
+pragmatická a strohá žena, zvyklá na drsné podmínky a neustálý psychický tlak. Má hluboké, praktické
+znalosti o projevech Prázdnoty, ale postrádá Kaelenovu teoretickou a filozofickou hloubku. Její
+přístup je založen na přežití a zadržování hrozby, ne na jejím pochopení.
 
 Dějiny:
 - +165 (cca) — Narodila se.
 - +185 až +210 — Sloužila na pozorovacích stanicích na severní hranici.
-- +215 (jaro) — Je jmenována vůdkyní expedice tří Šedých svědků, vyslané k Poslednímu bdění, aby prošetřila původ nové anomálie (viz Příběhy/jizva-ticha/1/2.txt).
+- +215 (jaro) — Je jmenována vůdkyní expedice tří Šedých svědků, vyslané k Poslednímu bdění, aby
+  prošetřila původ nové anomálie (viz Příběhy/jizva-ticha/1/2.txt).
 - +215 (jaro) — Vede expedici přes Les šepotů (viz Příběhy/jizva-ticha/1/3.txt).
+- +215 (jaro) — Konfrontuje Kaelena, který se k expedici připojil. Poté, co je svědkem útoku na
+  Joricovu mysl v Průsmyku bezejmenných a Kaelenovy záchrany, je nucena uznat platnost jeho varování
+  a přijmout ho jako člena expedice (viz Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Její jméno je ozvěnou jmen jiných postav (Rhea, pomocnice Eliana ze Silencie; Rhea, vůdkyně přeživších v Posledním bdění v příběhu o Lianovi), což může být tradice v řádu nebo ozvěna samotného světa.
+Její jméno je ozvěnou jmen jiných postav (Rhea, pomocnice Eliana ze Silencie; Rhea, vůdkyně
+přeživších v Posledním bdění v příběhu o Lianovi), což může být tradice v řádu nebo ozvěna samotného
+světa.

--- a/Objekty/concepts/sept-prazdnoty.txt
+++ b/Objekty/concepts/sept-prazdnoty.txt
@@ -6,11 +6,19 @@ aliasy: Odmazávání
 naposledy_upraveno: 2025-09-19
 
 Popis:
-Jemný, ale extrémně nebezpečný projev Tiché prázdnoty. Není to zvuk ani viditelná síla, ale proces "odmazávání" existence. Tento fenomén postupně odstraňuje objekty, myšlenky, vzpomínky a nakonec i živé bytosti z reality. Jeho postup je plíživý; oběti si často neuvědomují, co bylo ztraceno, cítí jen rostoucí zmatek a prázdnotu.
+Jemný, ale extrémně nebezpečný projev Tiché prázdnoty. Není to zvuk ani viditelná síla, ale proces
+'odmazávání' existence. Tento fenomén postupně odstraňuje objekty, myšlenky, vzpomínky a nakonec i
+živé bytosti z reality. V poslední době se projevuje i vkládáním falešných, cizorodých vzpomínek,
+které nahrazují původní identitu, zejména v oblastech zasažených Hlasem Nicoty.
 
 Dějiny:
-- +82 — Poprvé masivněji zaznamenán ve stanici Poslední bdění. Byl zastaven a "ukotven" Lianem, který vytvořil bariéru založenou na obětované, smysluplné vzpomínce (viz Příběhy/ctvrty-vek/sepot-v-prazdnote.txt).
+- +82 — Poprvé masivněji zaznamenán ve stanici Poslední bdění. Byl zastaven a 'ukotven' Lianem,
+  který vytvořil bariéru založenou na obětované, smysluplné vzpomínce (viz
+  Příběhy/ctvrty-vek/sepot-v-prazdnote.txt).
+- +215 (jaro) — V Průsmyku bezejmenných se projevil zesílený vliv Šepotu prázdnoty. Falešná ozvěna
+  dočasně přepsala identitu kartografa Jorica, dokud ho Kaelen neukotvil sdílenou vzpomínkou (viz
+  Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Šepot je považován za přirozenou "erozi", kterou Prázdnota působí na realitu. Předpokládá se, že podél celého okraje Prázdnoty mohou existovat další, menší "průsaky".
-
+Šepot je považován za přirozenou 'erozi', kterou Prázdnota působí na realitu. Předpokládá se, že
+podél celého okraje Prázdnoty mohou existovat další, menší 'průsaky'.

--- a/Objekty/places/prusmyk-bezejmennych.txt
+++ b/Objekty/places/prusmyk-bezejmennych.txt
@@ -1,19 +1,24 @@
-
-
 id: obj:places/prusmyk-bezejmennych
 jmeno: Průsmyk bezejmenných
 kategorie: places
-stav: nebezpecny
-aliasy: Dolní průsmyk
-naposledy_upraveno: 2025-09-15
+stav: nebezpecny (aktivně nepřátelský)
+aliasy: Dolní průsmyk, Průsmyk falešných jmen
+naposledy_upraveno: 2025-09-16
 
 Popis:
-Úzké sedlo mezi lesy, kde se myšlenky krajiny často shlukují do jediné, tíživé melodie.
-Lidé se mu vyhýbají od doby, kdy se v jeho hlubinách ztratila jména.
+Úzké sedlo mezi lesy, kde se myšlenky krajiny často shlukují do jediné, tíživé melodie. Původní
+anomálie tohoto místa způsobovala u poutníků ztrátu identity a vzpomínek, především jejich jmen.
+Vlivem Hlasu Nicoty se však tato anomálie zhoršila. Průsmyk nyní nejen aktivně "odmazává"
+identitu, ale nahrazuje ji silnými, falešnými ozvěnami – cizími osobnostmi a vzpomínkami, které
+mohou dočasně přepsat mysl oběti.
 
 Dějiny:
-- -1200-09-12 — Po střetu družiny se Stínem získal průsmyk nové jméno (viz Příběhy/druhy-vek/pochod-stinu.txt).
+- -1200-09-12 — Po střetu družiny se Stínem získal průsmyk nové jméno (viz
+  Příběhy/druhy-vek/pochod-stinu.txt).
+- +215 (jaro) — Expedice Šedých svědků zjišťuje, že anomálie průsmyku byla zesílena a zkažena
+  Hlasem Nicoty. Kartograf Joric je dočasně pohlcen falešnou identitou a je zachráněn Kaelenem,
+  který použije sdílenou pravdivou vzpomínku jako kotvu (viz Příběhy/jizva-ticha/1/4.txt).
 
 Poznámky:
-Původ fenoménu „ztracených jmen“ zůstává nejasný.
-
+Místo se stalo ještě nebezpečnějším. Už nejde jen o riziko ztráty paměti, ale o dočasnou ztrátu
+sebe sama ve prospěch cizího příběhu.

--- a/Příběhy/jizva-ticha/1/4.txt
+++ b/Příběhy/jizva-ticha/1/4.txt
@@ -1,0 +1,112 @@
+id: st:jizva-ticha/1/4
+nazev: Průsmyk falešných jmen
+era: ctvrty-vek
+casovy_rah: +215 (jaro)
+autor: Kronikář
+nemenny: ano
+
+Obsah:
+Strach byl vynikající palivo. Kaelen běžel. Už se neplížil. Každý šepot lesa, každá falešná ozvěna
+ho poháněla vpřed. Už to nebyla jen otázka neuposlechnutí rozkazu; byla to otázka přežití, nejen
+jeho, ale i těch, které pronásledoval. Musel je varovat. Musel jim říct, že nepřítel, se kterým
+bojují, není jen prázdnota, ale lež.
+
+Na konci třetího dne, vyčerpaný a s nohama těžkýma jako olovo, se konečně prosekal hustým podrostem
+na severním okraji Lesa šepotů. Před ním se otevřela kamenitá pláň, která se strmě zvedala k úzkému,
+zlověstnému sedlu mezi dvěma holými skalními masivy. Průsmyk bezejmenných.
+
+A tam, u jeho úpatí, v posledním světle zapadajícího slunce, uviděl slabý kouř táborového ohně.
+Expedice.
+
+Srdce mu poskočilo úlevou i novou vlnou úzkosti. Sebral poslední zbytky sil a zamířil k nim. Když se
+přiblížil, Orin, který seděl na kameni a ostřil si nůž, zvedl hlavu. Jeho oči se zúžily. Jediným
+plynulým pohybem stál na nohou, nůž pevně v ruce. Rhea, která seděla u ohně a studovala mapu s
+Joricem, se otočila. Její tvář ztvrdla v masku ledového hněvu.
+
+"Kaelene?" její hlas byl tichý, ale ostrý jako střep ledu. "Co tady děláš?"
+
+Kaelen se zastavil pár kroků od nich, zhluboka dýchal a snažil se najít slova. "Mistr Elian...
+poslal mě," zalhal, vědom si, jak chabě to zní.
+
+"Elian by nikdy nepodkopal mé velení," odpověděla Rhea a vstala. "A nikdy by neposlal učence
+samotného do Lesa šepotů. Mluv pravdu."
+
+"Utekl jsem," přiznal Kaelen. "Musel jsem. Objevil jsem něco v těch zprávách. Je to důležité."
+
+Rhea se hořce zasmála. "Něco jsi objevil? Chlapče, my žijeme na hranici s tou věcí. Ty čteš o ní v
+knihách. Vrať se, než se zraníš."
+
+"Ne, poslouchejte!" Kaelen udělal krok vpřed. "Není to tak, jak si myslíte. Ta anomálie, ten
+Šepot... on nemizí jen tak. Přepisuje. Lže! Zasahuje do paměti samotné země. V lese jsem to slyšel.
+Falešné ozvěny. Vzpomínky na věci, které se nikdy nestaly."
+
+Joric zvedl hlavu od svých map. Jeho tvář byla zmatená, ustaraná. "Moje mapy..." zamumlal. "Nesedí.
+Měřím vzdálenost, zapíšu ji. O hodinu později se podívám a zdá se mi, že je špatně. Jako by hora,
+kterou jsem včera viděl, měla jiný tvar v mé paměti."
+
+"To je přesně ono!" vykřikl Kaelen. "To není vaše paměť, co selhává. Je to paměť světa!"
+
+Rhea si je oba přeměřila pohledem, její skepse bojovala s narůstající nejistotou v Joricových očích.
+"Průsmyk odjakživa mate mysl. To je stará pravda. A Les šepotů je ještě horší. Vaše mysl si s vámi
+jen hraje."
+
+"A co když ne?" naléhal Kaelen. "Co když je stará anomálie průsmyku teď... zesílena? Co když je to
+past?"
+
+Na okamžik zavládlo ticho, přerušované jen praskáním ohně. Rhea nakonec s povzdechem rozhodla.
+"Poslat tě zpátky samotného je rozsudek smrti. Půjdeš s námi. Ale budeš se držet vzadu a nebudeš
+mluvit, pokud se tě nezeptám. Jsi teď moje zodpovědnost. A jestli nás ohrozíš, Kaelene, přísahám při
+paměti Riana, že tě tu nechám."
+
+Následujícího rána vstoupili do Průsmyku bezejmenných. Atmosféra se okamžitě změnila. Vítr zde
+nefoukal, jen se líně převaloval mezi skalami a nesl s sebou pocit tíživé ztráty. Byl to starý,
+známý efekt průsmyku – pomalé, plíživé otupování vlastní identity. Kaelen cítil, jak se mu jména
+jeho rodičů vzdalují, stávají se jen zvuky bez významu.
+
+Udržovali těsnou formaci, Rhea v čele, Kaelen na samém konci. Uprostřed dne, když procházeli nejužší
+částí sedla, se to stalo. Joric, který si neustále něco zapisoval do svého deníku, se náhle
+zastavil. Rozhlédl se s výrazem naprostého zmatení.
+
+"Musíme najít bezpečné kotviště," řekl jasným, pevným hlasem. "Bouře se blíží od západu. Loď to na
+otevřeném moři nevydrží."
+
+Rhea se k němu otočila. "Joricu, co to mluvíš? Jsme v horách."
+
+Joric se na ni podíval, jako by ji viděl poprvé. "Neříkejte mi Joric. Jmenuji se Haelen, kartograf
+expedice admirála Vora. A vy, paní, byste se měla vrátit do své kajuty."
+
+V tom okamžiku to zasáhlo i ostatní. Ne jako Joricův přelud, ale jako vlna prázdnoty. Kaelen se
+podíval na Rhea a na zlomek vteřiny zapomněl, proč tu jsou. Proč je s nimi? A kdo je ten muž, co
+mluví o lodích?
+
+Ale pak si vzpomněl. Vzpomněl si na symbol tří kruhů. Ozvěna bez zdroje. To nebyl Joric. To byl
+někdo jiný. Falešná vzpomínka, tak silná, že přepsala jeho osobnost. A s ní přišlo odmazávání –
+jejich vlastní paměť na Jorica byla napadena a téměř vymazána.
+
+"Je to lež!" vykřikl Kaelen a vrhl se k Joricovi, který už začal kreslit do svého deníku mapu
+neexistujícího pobřeží. "Joricu! Poslouchej mě! Tvoje jméno je Joric! Jsi z Údolí tichých ozvěn!
+Pamatuješ si Kamenný atlas?"
+
+Joric se na něj zmateně podíval. Jeho oči byly prázdné.
+
+Kaelen ho chytil za ramena a donutil ho podívat se mu do očí. Nesnažil se bojovat s falešnou
+vzpomínkou. Místo toho se soustředil na jednu, absolutně pravdivou. "Pamatuješ si rýhu pro 'hněv
+horské bystřiny'? Mistr Elian nám vyprávěl, že ji Rian tesal tři roky, protože nemohl najít ten
+správný tvar. Pamatuješ? Tu drsnou, hlubokou rýhu vedle hladké plochy pro 'klid'."
+
+Mluvil rychle, zoufale, sahal po společné, hmatatelné vzpomínce. Po kotvě. Na okamžik se nic
+nestalo. Pak se Joricovy oči zakalily. Zamrkal, jednou, dvakrát.
+
+"Atlas..." zašeptal. "Já... pamatuji si ten chladný kámen." Zmateně se rozhlédl po skalách. "Kde to
+jsme? Měl jsem... sen o moři." Třesoucí se rukou si setřel pot z čela.
+
+Orin přistoupil blíž a pevně položil Joricovi ruku na rameno, aby ho uzemnil. Rhea stála jako
+zkamenělá, pohled upřený na Kaelena. Veškerá její skepse, veškerý její hněv, se rozplynuly. Nahradil
+je chladný, profesionální strach.
+
+"Měl jsi pravdu," řekla tiše, její hlas bez jakékoli emoce. "Tohle není starý průsmyk. Je to něco
+nového. Něco horšího."
+
+Podívala se na Kaelena ne jako na chlapce, ale jako na zbraň, jejíž síle nerozuměla. Stáli uprostřed
+průsmyku, obklopeni tichem, které nejen kradlo, ale i lhalo. A Kaelen, učenec ze zapomenutého údolí,
+se právě stal jejich jediným expertem na válku se stíny.

--- a/timeline.txt
+++ b/timeline.txt
@@ -52,5 +52,10 @@
 - **+82**: Šedý svědek Lian zastavil anomálii Šepotu prázdnoty u stanice Poslední bdění za cenu obětování části své paměti. Událost vede ke změně doktríny řádu (viz Příběhy/ctvrty-vek/sepot-v-prazdnote.txt; Objekty/beings/lian-sedy-svedek.txt).
 - **+215 (jaro)**: Zprávy z Posledního bdění naznačují selhávání Lianovy kotvy a novou, aktivnější hrozbu z Tiché prázdnoty. Šedí svědkové vysílají expedici (Rhea, Orin, Joric). Mladý akolyta Kaelen se k nim tajně připojuje (viz Příběhy/jizva-ticha/1/1.txt; Příběhy/jizva-ticha/1/2.txt; Objekty/beings/rhea-seda-svedkyne.txt; Objekty/beings/orin-stopar.txt; Objekty/beings/joric-kartograf.txt; Objekty/beings/kaelen-z-udoli.txt; Objekty/beings/elian-mistr.txt; Objekty/places/posledni-bdeni.txt; Objekty/concepts/sedi-svedkove.txt).
 - **+215 (jaro)**: Kaelen sleduje expedici až do Lesa šepotů, kde se potvrzuje kontaminace paměti lesa "falešnými ozvěnami" a poprvé je zaznamenán přímý dotek odmazávání mimo bezprostřední hranici Tiché prázdnoty (viz Příběhy/jizva-ticha/1/3.txt; Objekty/beings/kaelen-z-udoli.txt; Objekty/places/les-sepotu.txt).
+- **+215 (jaro)**: Expedice Šedých svědků vstupuje do Průsmyku bezejmenných. Joricovu mysl krátce
+  přepíše falešná ozvěna a Kaelen ho vrací sdílenou vzpomínkou na Kamenný atlas, čímž si získá
+  Rheyinu důvěru (viz Příběhy/jizva-ticha/1/4.txt; Objekty/beings/kaelen-z-udoli.txt;
+  Objekty/beings/rhea-seda-svedkyne.txt; Objekty/beings/joric-kartograf.txt;
+  Objekty/places/prusmyk-bezejmennych.txt).
 
 


### PR DESCRIPTION
## Shrnutí
- přidán čtvrtý díl cyklu Jizva ticha zachycující střet expedice s falešnými ozvěnami v Průsmyku bezejmenných
- aktualizován popis průsmyku a záznamy Kaelena, Rhey, Jorica a Orina podle nové události
- upřesněno působení Šepotu prázdnoty a doplněna časová osa o průchod průsmykem

## Dotčené objekty
- obj:places/prusmyk-bezejmennych
- obj:beings/kaelen-z-udoli
- obj:beings/rhea-seda-svedkyne
- obj:beings/joric-kartograf
- obj:beings/orin-stopar
- obj:concepts/sept-prazdnoty

------
https://chatgpt.com/codex/tasks/task_e_68c941da1088833391d531c110c680a5