### PR TITLE
Přidání kapitoly 2/12 a aktualizace nosiče Písně

### DIFF
--- a/Objekty/beings/eamon-z-brehu.txt
+++ b/Objekty/beings/eamon-z-brehu.txt
@@ -27,6 +27,7 @@ Dějiny:
 - +215 (jaro/léto) — Dohlédne na finální tvarování mísy, předá Kaelenovi paličku ze spadlého parohu a svědčí vlně ticha, která potvrzuje návrat dědictví Strážců (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Organizuje nosítka pro Rezonanční mísu, vede družinu rychlejšími stezkami zpět k Jezeru odrazu a připravuje je na to, že s tichem mísy vstoupí do dalšího střetu (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Řídí druhý sestup u Jezera odrazu, provází Kaelena do ticha mísy a nabádá ho, aby přidal třetí hlas. Po vzniku nové Písně rovnováhy už plánuje, jak její harmonii rozšířit proti tomu, kdo naslouchá ve tmě (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Vede rituál, při němž Kaelen přijímá Píseň do svého nitra, a předává mu zodpovědnost Strážců. Určuje trasu na sever, kde musí živý nosič doručit harmonii proti Hlasu Nicoty (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Jeho jméno je poctou Eamonovi, legendárnímu Strážci jezera, který stvořil Píseň rovnováhy. Představuje čtvrtého klíčového člena "Společenstva Jizvy".

--- a/Objekty/beings/joric-kartograf.txt
+++ b/Objekty/beings/joric-kartograf.txt
@@ -35,6 +35,7 @@ Dějiny:
 - +215 (jaro/léto) — Dokumentuje Vorinovy grafy i Lyřiny stavy během finální fáze tvarování a zaznamená okamžik, kdy mísa vyšle vlnu ticha, jako nový typ mapovaného jevu (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Při návratu z Vřesové stráně zapisuje do deníku proměnu družiny v soudržné společenstvo a načrtává nový plán mapování cesty zpět k Jezeru odrazu s důrazem na vliv Rezonanční mísy (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Po zrodu nové Písně rovnováhy u Jezera odrazu se snaží zachytit její rytmus jako mapu harmonie. Zapisuje, jak lidský cit dokázal sjednotit prameny, a definuje nový cíl: mapovat šíření písně světem (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Dokumentuje rituál, při němž Kaelen přijímá Píseň do své mysli, a kreslí první mapu jejich budoucí cesty na sever. Uvědomuje si, že musí zaznamenávat nejen místa, ale i stav nosiče (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Jeho zkušenost z něj činí klíčového svědka pro pochopení mechanismu 'přepisování' reality.

--- a/Objekty/beings/kaelen-z-udoli.txt
+++ b/Objekty/beings/kaelen-z-udoli.txt
@@ -1,12 +1,12 @@
 id: obj:beings/kaelen-z-udoli
 jmeno: Kaelen z Údolí
 kategorie: beings
-stav: zivy (těžce narušený)
-aliasy: —
+stav: zivy (nosič Písně)
+aliasy: Nosič písně, Živoucí ladička
 naposledy_upraveno: 2025-10-01
 
 Popis:
-Mladý a idealistický akolyta řádu Šedých svědků, který vyrostl v Údolí tichých ozvěn. Je hluboce sečtělý v historii a legendách Věků, se zvláštním zaměřením na hrdinské činy minulosti. Má výjimečný cit pro Kamenný atlas, který nevnímá jen jako historický artefakt, ale jako živoucí text. Ačkoliv je teoreticky velmi zdatný, postrádá praktické zkušenosti se světem mimo bezpečí údolí.
+Mladý a idealistický akolyta řádu Šedých svědků, který vyrostl v Údolí tichých ozvěn. Je hluboce sečtělý v historii a legendách Věků, se zvláštním zaměřením na hrdinské činy minulosti. Má výjimečný cit pro Kamenný atlas, který nevnímá jen jako historický artefakt, ale jako živoucí text. Ačkoliv je teoreticky velmi zdatný, postrádá praktické zkušenosti se světem mimo bezpečí údolí. Po úspěšném stvoření Písně rovnováhy se dobrovolně stal jejím živým nosičem, aby ji mohl přenést na sever a postavit se Hlasu Nicoty. Tento proces ho trvale změnil; Píseň je nyní neoddělitelnou součástí jeho bytosti, což se projevuje subtilními změnami v jeho vzhledu a hlase. Jeho mysl je neustále v křehké rovnováze, kterou musí aktivně udržovat.
 
 Dějiny:
 - cca +195 — Narodil se v Údolí tichých ozvěn.
@@ -35,7 +35,8 @@ Dějiny:
 - +215 (jaro) — Během prvního dne rezonančního tvarování překládá Lyřiny vjemy pro Vorina, udržuje fokusátor ve správné rezonanci a vlastními vzpomínkami Lyru vrací do Lomu, když se její soustředění zlomí. Současně si s ní vytváří hlubší pouto založené na sdíleném tichu (viz Příběhy/jizva-ticha/2/8.txt).
 - +215 (jaro/léto) — Po týdnech péče o Lyru a koordinace tvarování Rezonanční mísy přijímá od Eamona paličku, probouzí nástroj a sdílí s družinou vlnu dokonalého ticha, která potvrzuje jeho roli "mostu" (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Na cestě zpět k Jezeru odrazu kráčí po boku nosítek Rezonanční mísy, dotykem s jejím rámem stabilizuje úlomky cizích vědomí ve své mysli a přijímá aktivnější vedení společenstva (viz Příběhy/jizva-ticha/2/10.txt).
-- +215 (léto) — Během druhého sestupu u Jezera odrazu, chráněn tichem Rezonanční mísy, propojí Hvězdnou mysl, paměť země a vlastní cit. Stává se dirigentem nové Písně rovnováhy a oporou pro celý spolek (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — S pomocí Rezonanční mísy, která vytvoří bezpečný most mezi prameny, se Kaelenovi podaří znovu propojit Hvězdnou mysl, paměť země a lidský cit. Stává se tak hlavním "dirigentem" a středobodem nové Písně rovnováhy (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Dobrovolně na sebe bere úkol stát se živým nosičem Písně rovnováhy. Během rituálu s Rezonanční mísou internalizuje harmonii, která opouští Jezero odrazu, a stává se součástí jeho duše. Tento akt ho trvale poznamená (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Jeho jméno je ozvěnou jmen významných postav minulosti (Kaelen, První mluvčí; kameník Kael; lovec Kaelan), což může symbolizovat tíhu dědictví, které nese.

--- a/Objekty/beings/lyra-z-tichych-vrchu.txt
+++ b/Objekty/beings/lyra-z-tichych-vrchu.txt
@@ -32,6 +32,7 @@ Dějiny:
 - +215 (jaro/léto) — Vyčerpávající měsíce tvarování jí zanechají kruhy pod očima a sny bez zvuku, ale vydrží až do dokončení a při probuzení mísy ji zaplaví slzy dokonalého ticha (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Na cestě zpět k Jezeru odrazu kráčí vedle Kaelena, oproštěná od neustálého naslouchání kameni, a znovu objevuje lehkost pohybu i zvědavost vůči světu mimo ticho (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Při druhém sestupu drží v Rezonanční míse tep paměti země dostatečně jemně, aby Kaelen mohl přidat lidský cit. Stává se svědkem zrodu nové Písně rovnováhy a sdílí s Kaelenem hlubší pouto (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Během rituálu, kdy se Kaelen stává živoucím nosičem Písně rovnováhy, ho drží za ruce a slouží jako jeho lidská kotva. Připravuje se ho ochránit na cestě na sever (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Její jméno je další v řadě jmen "Lyra", což může symbolizovat archetypální roli, kterou tyto postavy v různých érách hrají. Její schopnosti jsou přímým protikladem Kaelenových, založených na paměti a ozvěnách.

--- a/Objekty/beings/orin-stopar.txt
+++ b/Objekty/beings/orin-stopar.txt
@@ -34,6 +34,7 @@ Dějiny:
 - +215 (jaro/léto) — Během procesu tvorby mísy, ovlivněn jejím pohlcujícím tichem, projeví další známku zotavení, když poprvé od svého zranění promluví a znovu si uvědomí vlastnictví svého těla (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Během cesty zpět k Jezeru odrazu, chráněn aurou ticha Rezonanční mísy, projeví další známku zotavení, když se v něm probudí jeho staré stopařské instinkty (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Když nová Píseň rovnováhy zazní u Jezera odrazu, Orin ji cítí ve svých kostech a na okamžik znovu splyne se svým tělem. Harmonie mu nabízí nejjasnější záblesk uzdravení od střetu s Vymazaným (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Stojí po boku Kaelena během rituálu přenesení Písně a jeho nově zklidněná mysl přijímá úkol chránit nosiče na cestě na sever. Slíbí, že svou tichou bdělostí vycítí každé ohrožení (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Jeho stav je živoucím důkazem o nebezpečí Hlasu Nicoty. Jeho budoucí osud je nejistý.

--- a/Objekty/beings/rhea-seda-svedkyne.txt
+++ b/Objekty/beings/rhea-seda-svedkyne.txt
@@ -36,6 +36,7 @@ Dějiny:
 - +215 (jaro/léto) — Sleduje dokončení Rezonanční mísy, při jejím probuzení poprvé povolí sevření meče a přijme ticho jako zbraň, kterou družina ponese zpět k Jezeru odrazu (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Vede organizaci pochodu při odchodu z Vřesové stráně, rozděluje zátěž Rezonanční mísy a přijímá Eamonovo označení ticha jako zbraně, s níž se vrátí k Jezeru odrazu (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Během druhého sestupu u Jezera odrazu drží stráž a sleduje, jak Kaelenův cit zkrotí střet pramenů. Stává se svědkem zrodu nové Písně rovnováhy a přesměrovává svou strategii na její šíření (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Dozoruje ochranu rituálu, při němž Kaelen internalizuje Píseň rovnováhy, a okamžitě plánuje novou výpravu na sever, aby chránila živého nosiče před hrozbami prázdnoty (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Její jméno je ozvěnou jmen jiných postav (Rhea, pomocnice Eliana ze Silencie; Rhea, vůdkyně přeživších v Posledním bdění v příběhu o Lianovi), což může být tradice v řádu nebo ozvěna samotného světa.

--- a/Objekty/beings/vorin-ze-silencie.txt
+++ b/Objekty/beings/vorin-ze-silencie.txt
@@ -32,6 +32,7 @@ Dějiny:
 - +215 (jaro/léto) — Fascinován korelací Lyřiny únavy s čistotou rezonance, vede detailní záznamy a po probuzení mísy přijímá, že data a duše mohou sdílet jeden výsledek (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Během cesty zpět k Jezeru odrazu spolu s Eamonem nese Rezonanční mísu na speciálních nosítkách a analyzuje její ticho jako ochranný filtr, který stabilizuje mysl družiny (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — U Jezera odrazu vede druhý sestup opatrněji, nechává fokusátor následovat Lyřiny signály a sleduje, jak Kaelenův cit sladí data obou pramenů. Uzavírá, že nová Píseň rovnováhy je důkazem, že logika musí sloužit lidskému středu (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Asistuje u rituálu přenesení Písně, kalibruje Rezonanční mísu jako fokusátor a vyhodnocuje Kaelena jako jediný bezpečný nosič. Plánuje, jak logicky rozmístit budoucí rezonátory podél jejich severní cesty (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Jeho jméno je ozvěnou jména Vorina, zakladatele Silencie, což odráží jeho hluboké spojení s historií a dědictvím města.

--- a/Objekty/concepts/pisen-rovnovahy.txt
+++ b/Objekty/concepts/pisen-rovnovahy.txt
@@ -1,12 +1,12 @@
 id: obj:concepts/pisen-rovnovahy
 jmeno: Píseň rovnováhy
 kategorie: concepts
-stav: existuje (lokálně)
+stav: existuje (internalizovaná)
 aliasy: Trojzvuk
 naposledy_upraveno: 2025-09-26
 
 Popis:
-Legendární harmonie stvořená Strážcem Eamonem u Jezera odrazu. Nejedná se o slyšitelnou píseň, ale o dokonalou rezonanci mezi třemi fundamentálními, ale protichůdnými principy: chladnou, sterilní logikou Hvězdné mysli; chaotickou, organickou pamětí Země; a lidským citem (láskou a obětí), který slouží jako most. Tato harmonie dokázala na tisíciletí utišit chaos Jezera odrazu. Původní Píseň již neexistuje, ale její slabá, prchavá ozvěna stále přetrvává v hlubinách jezera.
+Legendární harmonie stvořená Strážcem Eamonem u Jezera odrazu. Nejedná se o slyšitelnou píseň, ale o dokonalou rezonanci mezi třemi fundamentálními, ale protichůdnými principy: chladnou, sterilní logikou Hvězdné mysli; chaotickou, organickou pamětí Země; a lidským citem (láskou a obětí), který slouží jako most. Tato harmonie dokázala na tisíciletí utišit chaos Jezera odrazu. Původní Píseň již neexistuje, ale její slabá, prchavá ozvěna přetrvávala v hlubinách jezera až do stvoření nové verze, která nyní přebývá v mysli Kaelena jako živého nosiče.
 
 Dějiny:
 
@@ -15,6 +15,7 @@ Dějiny:
 - +215 (jaro) — Skupina novodobých Ladičů se pokouší Píseň znovu vytvořit jako zbraň proti Hlasu Nicoty (viz Příběhy/jizva-ticha/2/1.txt).
 - +215 (jaro) — Po přerušení prvního pokusu Ladiči pochopí, že k bezpečnému mostu je nezbytná Rezonanční mísa, a zaměří se na získání materiálu z Lomu tichých vzdechů (viz Příběhy/jizva-ticha/2/2.txt).
 - +215 (léto) — Novodobí Ladiči s pomocí Rezonanční mísy vytvářejí u Jezera odrazu novou, komplexnější verzi Písně rovnováhy. Její vliv je zatím omezen na jezero a jeho okolí, ale stává se potenciálním nástrojem proti Hlasu Nicoty (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Píseň je pomocí rituálu přenesena z Jezera odrazu a "uložena" do vědomí Kaelena z Údolí, který se stává jejím živým nosičem. Jezero po tomto aktu utichá (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Píseň není lék, který zničí nerovnováhu, ale harmonie, která jí dává smysl a místo ve struktuře reality. Její vytvoření vyžaduje obrovskou mentální sílu a osobní oběť.

--- a/Objekty/jizva-ticha.txt
+++ b/Objekty/jizva-ticha.txt
@@ -32,6 +32,7 @@ Dějiny:
 - +215 (jaro/léto) — Kniha Druhá, Kapitola 9: Po týdnech práce je Rezonanční mísa dokončena. Její první aktivace vyšle vlnu mentálního ticha, která potvrdí úspěch a připraví skupinu na návrat k Jezeru odrazu (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Kniha Druhá, Kapitola 10: Skupina opouští Osadu Vřesová stráň a vydává se na cestu zpět k Jezeru odrazu. Nesou s sebou nově vytvořenou Rezonanční mísu. Jejich dynamika je změněna a jejich mise vstupuje do nové, aktivní fáze (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Kniha Druhá, Kapitola 11: U Jezera odrazu Ladiči s pomocí Rezonanční mísy provedou druhý sestup. Kaelen v tichu nástroje propojí Hvězdnou mysl, paměť země a lidský cit do nové Písně rovnováhy, která harmonizuje jezero a otevírá další fázi jejich poslání (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Kniha Druhá, Kapitola 12: Skupina dochází k poznání, že Píseň musí být aktivně nesena živým nosičem. Kaelen na sebe bere tento úkol, pomocí Rezonanční mísy do sebe "vtiskne" Píseň rovnováhy a jezero po tomto aktu utichá. Mise se mění v cestu za doručením písně na sever (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Tento meta objekt slouží ke sledování hlavního dějového oblouku trilogie.

--- a/Objekty/places/jezero-odrazu.txt
+++ b/Objekty/places/jezero-odrazu.txt
@@ -1,12 +1,12 @@
 id: obj:places/jezero-odrazu
 jmeno: Jezero odrazu
 kategorie: places
-stav: trvale (proměnlivý chaos)
+stav: trvale (utišené)
 aliasy: Rána světa
 naposledy_upraveno: 2025-09-26
 
 Popis:
-Prastaré jezero, které vzniklo jako "rána" ve vědomí světa po dopadu cizí, Hvězdné mysli (událost Tichý pád). Jeho voda je prosycena pamětí Země, která se snaží zahojit tuto jizvu. Šepot jezera je chaotickou směsicí myšlenek krajiny, snů živých tvorů a především zmateného vědomí utopené Hvězdné mysli.
+Prastaré jezero, které vzniklo jako "rána" ve vědomí světa po dopadu cizí, Hvězdné mysli (událost Tichý pád). Jeho voda je prosycena pamětí Země, která se snaží zahojit tuto jizvu. Po staletí v něm zněla chaotická směsice myšlenek krajiny, snů živých tvorů a především zmateného vědomí utopené Hvězdné mysli. Po přenesení nové Písně rovnováhy do živého nosiče se jezero uklidnilo a stalo se tichým, prázdným nástrojem bez vlastní rezonance.
 
 Dějiny:
 - První věk (dávno) — Vzniklo následkem Tichého pádu. Na jeho březích se usídlil rod Strážců jezera.
@@ -19,7 +19,8 @@ Dějiny:
 - +215 (jaro) — Jeho chaotický mentální vliv je citelný na mnoho mil daleko, způsobuje zmatené sny a emoční nestabilitu. Skupina vedená Eamonem z Břehů dorazí na jeho břehy ve snaze nalézt tajemství Písně rovnováhy (viz Příběhy/jizva-ticha/1/13.txt).
 - +215 (jaro) — Během mentálního cvičení vedeného Eamonem se z chaosu ozvěn na okamžik vynoří jediný čistý tón, ozvěna původní Písně rovnováhy, což potvrzuje, že její fragmenty v jezeře stále přebývají (viz Příběhy/jizva-ticha/1/14.txt).
 - +215 (jaro) — Novodobí Ladiči zde zahajují první mentální sestup: Vorin izoluje logický tón Hvězdné mysli, Lyra zachytí tep paměti Země, ale jejich střet skrze Kaelena téměř roztrhá lidský most mezi prameny (viz Příběhy/jizva-ticha/2/1.txt).
-- +215 (léto) — S Rezonanční mísou se Ladiči vracejí k jezeru a Kaelen v jejím tichu propojí prameny s lidským citem. Jezero na okamžik zazpívá novou Píseň rovnováhy a jeho hladina reaguje soustřednými vlnami harmonie (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Píseň rovnováhy je v jezeře plně obnovena a na okamžik zaplaví krajinu soustřednými vlnami harmonie (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Píseň je přenesena do Kaelena, živého nosiče. Jezero ztrácí svou chaotickou i harmonickou mentální rezonanci a stává se klidným, tichým jezerem bez anomálie (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
-Stav jezera je nestabilní. Období klidu se střídají s obdobími chaosu v závislosti na vnějších vlivech a vnitřní rovnováze. "Píseň u jezera" nebyla přirozeností jezera, ale dočasnou harmonií vytvořenou Eamonem. Nynější chaos je pravděpodobně ještě zesílen blízkostí Hlasu Nicoty.
+Po přenesení Písně do Kaelena se jezero poprvé po staletích nachází v klidném, prázdném tichu. Není jasné, zda se někdy znovu rozezpívá, nebo zda jeho úlohou zůstane být pouhou ozvěnou harmonii nesené živým nosičem.

--- a/Objekty/things/rezonancni-misa.txt
+++ b/Objekty/things/rezonancni-misa.txt
@@ -20,6 +20,7 @@ Dějiny:
 - +215 (léto) — Kaelen ji poprvé "probudí" úderem. Mísa vydá vlnu čistého mentálního ticha, čímž potvrdí svou funkčnost (viz Příběhy/jizva-ticha/2/9.txt).
 - +215 (léto) — Během návratu z Vřesové stráně je nesena na speciálních nosítkách, vytváří kolem družiny pohyblivou kapsu ticha a chrání jejich mysl před okolními ozvěnami (viz Příběhy/jizva-ticha/2/10.txt).
 - +215 (léto) — Při druhém sestupu u Jezera odrazu slouží jako mentální filtr, který Kaelenovi umožní oddělit prameny a vložit lidský cit. Její rezonance je klíčem k zrodu nové Písně rovnováhy (viz Příběhy/jizva-ticha/2/11.txt).
+- +215 (léto) — Při rituálu, během něhož se Kaelen stává živým nosičem Písně rovnováhy, funguje jako fokusátor, který nasměruje harmonii jezera do jeho mysli a uzamkne ji v jediném nosiči (viz Příběhy/jizva-ticha/2/12.txt).
 
 Poznámky:
 Nová mísa je produktem spolupráce dvou zcela odlišných filozofií (vědy a intuice), což symbolizuje cíl celé mise.

--- a/Příběhy/jizva-ticha/2/12.txt
+++ b/Příběhy/jizva-ticha/2/12.txt
@@ -1,0 +1,47 @@
+id: st:jizva-ticha/2/12
+nazev: Nosič písně
+era: ctvrty-vek
+casovy_rah: +215 (léto)
+autor: Kronikář
+nemenny: ano
+
+Obsah:
+
+Dny, které následovaly, byly jako žít v srdci dokonalé hudby. Mentální chaos Jezera odrazu byl pryč, nahrazen stálou, klidnou rezonancí nové Písně rovnováhy. Okolní příroda na to reagovala. Barvy se zdály být jasnější, vzduch čistší. Dokonce i Orin začal znovu mluvit v krátkých, úsečných větách, jeho mysl ukotvená v nově nalezené harmonii. Úspěch byl opojný. A právě proto byl nebezpečný.
+
+"Nemůžeme tu zůstat," řekla Rhea čtvrtý den. Seděli u ohně a sledovali, jak se světlo zapadajícího slunce odráží v dokonalém klidu Rezonanční mísy. "Každý den, co jsme tady, se na severu ta... věc... šíří dál."
+
+"Má pravdu," přidal se Vorin. "Máme lék. Teď musíme najít způsob, jak ho podat pacientovi. Problém je, že pacient je celý svět a lék je nehmotná rezonance, která existuje jen tady." Jeho prsty netrpělivě bubnovaly o koleno. "Potřebujeme vysílač. Síť rezonátorů, rozmístěných strategicky po celém Srdci světa. Mohli bychom použít mísu jako matrici a vytvořit menší, přenosné verze..."
+
+"Ne," přerušil ho Eamon jemně, ale pevně. "Píseň není zpráva, kterou můžeš poslat po drátě. Není to informace. Je to stav bytí. Nelze ji vysílat. Musí se nést."
+
+"Nést jak?" zeptal se Vorin. "Na ramenou, jako tu vaši mísu?"
+
+"Uvnitř," řekl Eamon a jeho pohled se upřel na Kaelena. "Musí ji nést živá bytost. Někdo, jehož mysl je dostatečně silná, aby ji udržela, a dostatečně soucitná, aby ji nezneužila. Musí se stát živoucí ladičkou."
+
+Ticho, které následovalo, bylo těžší než ticho kamene. Všichni pochopili, co to znamená. Co to vyžaduje. Stát se trvalým mostem mezi třemi kosmickými silami.
+
+"Já to udělám," řekl Kaelen a v jeho hlase nebyla pýcha, jen tichá, nevyhnutelná jistota. Cítil to. Píseň, kterou pomohl stvořit, v něm stále tiše rezonovala. Byla už součástí jeho bytosti.
+
+"Ne," řekla Lyra okamžitě, její hlas byl ostrý. "Viděla jsem, co to s tebou udělalo poprvé. Tohle by tě zničilo. Rozpustilo by tě to v té harmonii."
+
+"Možná," připustil Kaelen. "Ale jaká je alternativa? Nechat svět, aby byl vymazán? Všechny naše znalosti, všechny naše kotvy, byly jen přípravou na tento okamžik." Podíval se na Eamona. "Jak?"
+
+Eamon přikývl. "Pomocí mísy. Tentokrát ne jako filtru, ale jako fokusátoru. Neoddělí prameny, ale spojí je a nalije je... do tebe. Musíš se otevřít a přijmout píseň ne jako hosta, ale jako svou vlastní duši."
+
+Rituál provedli za úsvitu následujícího dne. Scéna byla podobná jako při stvoření písně, ale role byly jiné. Kaelen si sedl doprostřed kamenného výběžku a před sebe položil Rezonanční mísu. Nebyl už jen dirigentem. Byl nástrojem, který měl být naladěn.
+
+Lyra usedla naproti němu a položila své dlaně na jeho. Nebyla tam, aby hledala ticho země. Byla tam, aby ho držela, aby byla jeho kotvou ve světě lidí, až se jeho mysl dotkne kosmu. Ostatní opět vytvořili ochranný kruh, jejich tichá podpora byla štítem proti jakémukoliv rušení.
+
+Kaelen se zhluboka nadechl a udeřil do mísy.
+Vlna dokonalého ticha se nešířila ven, ale dovnitř. Mísa začala rezonovat a stahovat Píseň rovnováhy, která pulzovala jezerem, do sebe. A z ní, jako neviditelný proud, začala píseň proudit do Kaelena.
+
+Nebyla to bolest jako minule. Bylo to něco mnohem intenzivnějšího. Bylo to rozpuštění. Cítil, jak se hranice jeho těla a mysli hroutí. Přestal být Kaelenem, chlapcem z Údolí. Stal se vším. Byl chladnou logikou hvězd i slepým tepem života. Byl kamenem, vodou, světlem i stínem. A uprostřed toho všeho, jako zlatá nit, cítil teplo Lyřiných rukou, které ho držely a připomínaly mu, kým byl.
+
+Trvalo to jen minutu, ale v té minutě prožil věčnost. Když proud ustal a mísa ztichla, Kaelen otevřel oči.
+Byly jiné. Jejich barva byla stejná, ale v jejich hloubce tančily drobné, sotva znatelné jiskřičky světla, jako vzdálené hvězdy. A když promluvil, jeho hlas byl stejný, ale pod ním zněl tichý, harmonický podtón.
+"Jsem připraven," řekl.
+
+Jezero za ním bylo jiné. Už nezpívalo. Bylo tiché. Ne chaotickým, hlučným tichem jako dřív. Ale klidným, prázdným tichem. Jako nástroj, na který se právě dohrálo. Píseň zmizela z vody. Byla teď uvnitř Kaelena.
+
+Vstali, aby se vydali na cestu zpět. Jejich úkol byl nyní jasný a děsivý. Museli dopravit křehkou nádobu s nejmocnější písní světa skrze nemocnou zemi přímo do srdce ticha, které chtělo zničit všechny písně. A jejich naděje závisela na tom, zda se ta nádoba cestou nerozbije.


### PR DESCRIPTION
## Summary
- přidána kapitola "Nosič písně" popisující Kaelenův rituál u Jezera odrazu
- aktualizovány objekty Kaelena, Písně rovnováhy, Jezera odrazu, Rezonanční mísy a ostatních členů družiny o důsledky rituálu a přípravu na cestu na sever

## Testing
- not run (text-only repository)


------
https://chatgpt.com/codex/tasks/task_e_68ca762af01c8333ae3fac37a0167ed4